### PR TITLE
Fixed mistake in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ look like this:
 
 ```python
  >>> from newportxps import NewportXPS
- >>> xps = NewportXPS('164.54.160.000', user='Administrator', password='Please.Let.Me.In')
+ >>> xps = NewportXPS('164.54.160.000', username='Administrator', password='Please.Let.Me.In')
  >>> print(xps.status_report())
  # XPS host:         164.54.160.000 (164.54.160.000)
  # Firmware:         XPS-D-N13006

--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -543,7 +543,7 @@ class NewportXPS:
             min_jerktime = jt0_cur
         if max_jerktime is None:
             max_jerktime = jt1_cur
-        self._xps.PositionerSGammaParametersGet(self._sid, stage, vel, accl,
+        self._xps.PositionerSGammaParametersSet(self._sid, stage, velo, accl,
                                                 min_jerktime, max_jerktime)
 
     @withConnectedXPS


### PR DESCRIPTION
NewportXPS constructor has a parameter called 'username', it does not have a
parameter called 'user'.