### PR TITLE
Clean TMP and CoreDump folders for XPS-D

### DIFF
--- a/newportxps/XPS_C8_drivers.py
+++ b/newportxps/XPS_C8_drivers.py
@@ -2047,6 +2047,8 @@ class XPS:
     def TestTCP (self, socketId, InputString):
         return self.Send(socketId, 'TestTCP(%s, char *)' % InputString)
 
+    # ========== Only for XPS-D ==========
+
     # CleanCoreDumpFolder :   Remove core file in /Admin/Public/CoreDump folder
     def CleanCoreDumpFolder (self, socketId):
         return self.Send(socketId, 'CleanCoreDumpFolder()')

--- a/newportxps/XPS_C8_drivers.py
+++ b/newportxps/XPS_C8_drivers.py
@@ -2046,3 +2046,11 @@ class XPS:
     # TestTCP :  Test TCP/IP transfert
     def TestTCP (self, socketId, InputString):
         return self.Send(socketId, 'TestTCP(%s, char *)' % InputString)
+
+    # CleanCoreDumpFolder :   Remove core file in /Admin/Public/CoreDump folder
+    def CleanCoreDumpFolder (self, socketId):
+        return self.Send(socketId, 'CleanCoreDumpFolder()')
+
+    # CleanTmpFolder :   Clean the tmp folder
+    def CleanTmpFolder(self, socketId):
+        return self.Send(socketId, 'CleanTmpFolder()')

--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -878,13 +878,17 @@ class NewportXPS:
         self.traj_state = ARMED
 
     @withConnectedXPS
-    def run_trajectory(self, name=None, save=True,
+    def run_trajectory(self, name=None, save=True, clean=False,
                        output_file='Gather.dat', verbose=False):
 
         """run a trajectory in PVT mode
 
         The trajectory *must be in the ARMED state
         """
+
+        if clean:
+            self._xps.CleanCoreDumpFolder(self._sid)
+            self._xps.CleanTmpFolder(self._sid)
 
         if name in self.trajectories:
             self.arm_trajectory(name)

--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -886,9 +886,11 @@ class NewportXPS:
         The trajectory *must be in the ARMED state
         """
 
-        if clean:
-            self._xps.CleanCoreDumpFolder(self._sid)
+        if 'xps-d' in self.firmware_version.lower():
             self._xps.CleanTmpFolder(self._sid)
+
+            if clean:
+                self._xps.CleanTmpFolder(self._sid)
 
         if name in self.trajectories:
             self.arm_trajectory(name)

--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -890,7 +890,7 @@ class NewportXPS:
             self._xps.CleanTmpFolder(self._sid)
 
             if clean:
-                self._xps.CleanTmpFolder(self._sid)
+                self._xps.CleanCoreDumpFolder(self._sid)
 
         if name in self.trajectories:
             self.arm_trajectory(name)


### PR DESCRIPTION
Added CleanCoreDumpFolder and CleanTmpFolder commands. By default, only for XPS-D, the CleanTmpFolder runs every time with the run_trajectory method, and the ClearCoreDumpFolder runs if the clean argument is set to true.