### PR TITLE
Lockhart typo 1

### DIFF
--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -113,7 +113,7 @@ class NewportXPS:
         self.firmware_version = val
         self.ftphome = ''
 
-        if any([m 'XPS-D' in self.firmware_version for m in ['XPS-D', 'HXP-D']]):
+        if any([m in self.firmware_version for m in ['XPS-D', 'HXP-D']]):
             err, val = self._xps.Send(self._sid, 'InstallerVersionGet(char *)')
             self.firmware_version = val
             self.ftpconn = SFTPWrapper(**self.ftpargs)

--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -113,8 +113,7 @@ class NewportXPS:
         self.firmware_version = val
         self.ftphome = ''
 
-        if ('XPS-D' in self.firmware_version:
-            'HXP-D' in self.firmware_version):
+        if any([m 'XPS-D' in self.firmware_version for m in ['XPS-D', 'HXP-D']]):
             err, val = self._xps.Send(self._sid, 'InstallerVersionGet(char *)')
             self.firmware_version = val
             self.ftpconn = SFTPWrapper(**self.ftpargs)


### PR DESCRIPTION
Fix a typo when looking for a device match in the firmware version info.
Consolidated to a single line using an any() function but no problem if you want to just an an "or" to the existing code.