### PR TITLE
remove default socket timeout

### DIFF
--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -38,7 +38,6 @@ class NewportXPS:
                  port=5001, timeout=10, extra_triggers=0,
                  outputs=('CurrentPosition', 'SetpointPosition')):
 
-        socket.setdefaulttimeout(5.0)
         try:
             host = socket.gethostbyname(host)
         except:


### PR DESCRIPTION
Is this default socket timeout really necessary?  It was causing my program to terminate early.  I've removed it here and it seems to still work.

If it is necessary, is there a better way to set it for the sockets used instead of setting it for all sockets used by python?