### PR TITLE
Don't reinitialize global variables when creating an XPS object

### DIFF
--- a/newportxps/XPS_C8_drivers.py
+++ b/newportxps/XPS_C8_drivers.py
@@ -14,6 +14,7 @@
 
 import sys
 import socket
+from collections import defaultdict
 
 from .utils import bytes2str, str2bytes
 
@@ -30,14 +31,11 @@ class XPS:
 
     # Global variables
     __sockets = {}
-    __usedSockets = {}
+    __usedSockets = defaultdict(int)
     __nbSockets = 0
 
     # Initialization Function
     def __init__ (self):
-        XPS.__nbSockets = 0
-        for socketId in range(self.MAX_NB_SOCKETS):
-            XPS.__usedSockets[socketId] = 0
         self.errorcodes = {}
 
     def withValidSocket(fcn):


### PR DESCRIPTION
This allows creating multiple NewportXPS objects in one process and accessing them from different threads (each with their own unique socket and XPS object).