### PR TITLE
Add compatibility for newest firmware

### DIFF
--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -110,7 +110,7 @@ class NewportXPS:
         self.firmware_version = val
         self.ftphome = ''
 
-        if any([m in self.firmware_version for m in ['XPS-D', 'HXP-D']]):
+        if any([m in self.firmware_version for m in ['XPS-D', 'HXP-D', 'XPS-RL']]):
             err, val = self._xps.Send(self._sid, 'InstallerVersionGet(char *)')
             self.firmware_version = val
             self.ftpconn = SFTPWrapper(**self.ftpargs)


### PR DESCRIPTION
We got the newest version of the XPS controller that came with XPS-RL firmware. Just adding the new firmware in line 113 of newportxps.py fixed the issue for us.
Without the change the "Could not read system.ini" message will appear.