### PR TITLE
fixes move issue

### DIFF
--- a/newportxps/newportxps.py
+++ b/newportxps/newportxps.py
@@ -1023,13 +1023,12 @@ class NewportXPS:
         traj = self.get_trajectory(name, verify_group=True)
         tgroup = self.traj_group
         if traj['type'] == 'line':
-            for pos, axes in zip(traj['start'], traj['axes']):
-                self.move_stage(f'{tgroup}.{axes}', pos)
+            kwargs = {ax.lower(): pos for ax, pos in zip(traj['axes'], traj['start'])}
+            self.move_group(tgroup, **kwargs)
 
         elif traj['type'] == 'array':
-            for axes, pos in traj['start'].items():
-                if pos is not None:
-                    self.move_stage(f'{tgroup}.{axes}', pos)
+            kwargs = {k.lower(): v for k, v in traj['start'].items() if v is not None}
+            self.move_group(tgroup, **kwargs)
 
     @withConnectedXPS
     def arm_trajectory(self, name, verbose=False, move_to_start=True, group=None):


### PR DESCRIPTION
switches move to use move_group (group name) so that GroupMoveAbsolut](https://github.com/pyepics/newportxps/commit/72424e3316d9b71bd91a968b2c4c846ca85b3672)e is called with the actual group name. Calling move_stage with 'Group.Positioner' can trigger XPS error -22 (Not allowed action) on controllers that only accept group names for GroupMoveAbsolute.